### PR TITLE
1.19 & config added to customize cloud distance (with expanded projection mapping to allow much further clouds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Extended Clouds
 
 ## Description
-Makes the clouds render further out. This codebase is really simple, its just 2 files.
+Makes the clouds render further out.
+
+This codebase ~~is really simple, its just 2 files.~~ now allows 
+customizations of how far clouds render relative to the chunk render distance, and only affects cloud rendering.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Makes the clouds render further out.
 
 This codebase ~~is really simple, its just 2 files.~~ now allows 
 customizations of how far clouds render relative to the chunk render distance, and only affects cloud rendering.
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.1
-	loader_version=0.13.3
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.4
+	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 1.0.1
+	mod_version = 2.0.0-traben-PR
 	maven_group = net.oskarstrom
 	archives_base_name = extendedclouds

--- a/src/main/java/net/oskarstrom/extendedclouds/ClientEntrypoint.java
+++ b/src/main/java/net/oskarstrom/extendedclouds/ClientEntrypoint.java
@@ -1,0 +1,59 @@
+package net.oskarstrom.extendedclouds;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.util.math.Matrix4f;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ClientEntrypoint implements ClientModInitializer {
+
+    public static Config cloudConfigData;
+
+    public static Matrix4f matrix4fForCloudsOnly = null;
+
+    @Override
+    public void onInitializeClient() {
+        ec$loadConfig();
+    }
+
+    public static void ec$loadConfig() {
+        File config = new File(FabricLoader.getInstance().getConfigDir().toFile(), "extended-clouds.json");
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        if (config.exists()) {
+            try {
+                FileReader fileReader = new FileReader(config);
+                cloudConfigData = gson.fromJson(fileReader, Config.class);
+                fileReader.close();
+                ec$saveConfig();
+            } catch (IOException e) {
+                cloudConfigData = new Config();
+                ec$saveConfig();
+            }
+        } else {
+            cloudConfigData = new Config();
+            ec$saveConfig();
+        }
+    }
+    public static void ec$saveConfig() {
+        File config = new File(FabricLoader.getInstance().getConfigDir().toFile(), "extended-clouds.json");
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        if (!config.getParentFile().exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            config.getParentFile().mkdir();
+        }
+        try {
+            FileWriter fileWriter = new FileWriter(config);
+            fileWriter.write(gson.toJson(cloudConfigData));
+            fileWriter.close();
+        } catch (IOException e) {
+            //logError("Config file could not be saved", false);
+        }
+    }
+
+}

--- a/src/main/java/net/oskarstrom/extendedclouds/Config.java
+++ b/src/main/java/net/oskarstrom/extendedclouds/Config.java
@@ -1,0 +1,16 @@
+package net.oskarstrom.extendedclouds;
+
+public class Config {
+
+    public final String _comment_ = "renderDistanceToCloudModifier will set the distance that clouds render, relative to your render distance, 1.0 is render distance, WARNING if this is set too high you might crash";
+    @SuppressWarnings("FieldCanBeLocal")
+    public final double renderDistanceToCloudModifier = 2;
+
+    //needs to be above 0
+    public double getTestedModifier(){
+        //noinspection ConstantConditions
+        if (renderDistanceToCloudModifier <= 0) return 0.1;
+        return renderDistanceToCloudModifier;
+    }
+
+}

--- a/src/main/java/net/oskarstrom/extendedclouds/mixin/GameRendererMixin.java
+++ b/src/main/java/net/oskarstrom/extendedclouds/mixin/GameRendererMixin.java
@@ -1,0 +1,60 @@
+package net.oskarstrom.extendedclouds.mixin;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Matrix4f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.oskarstrom.extendedclouds.ClientEntrypoint.cloudConfigData;
+import static net.oskarstrom.extendedclouds.ClientEntrypoint.matrix4fForCloudsOnly;
+
+@Mixin(GameRenderer.class)
+public abstract class GameRendererMixin{
+
+	@Shadow
+	protected abstract double getFov(Camera cam, float delta, boolean changeFov);
+	@Final
+	@Shadow
+	private Camera camera;
+	@Final
+	@Shadow
+	private MinecraftClient client;
+	@Shadow
+	private float zoom;
+	@Shadow
+	private float zoomX;
+	@Shadow
+	private float zoomY;
+	@Shadow
+	public abstract float method_32796();
+
+	@Inject(method = "renderWorld", at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/client/render/WorldRenderer;render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V",
+			shift = At.Shift.BEFORE))
+	private void injected(float tickDelta, long limitTime, MatrixStack matrices, CallbackInfo ci) {
+		//this code is a copy of the construction of the vanilla projection matrix but has had it's distance extended
+		//this will be stored and only used for clouds later
+		MatrixStack matrixStack = new MatrixStack();
+		double d = this.getFov(this.camera, tickDelta, true);
+		matrixStack.peek().getPositionMatrix().multiply(this.getLongerBasicProjectionMatrix(d));
+		matrix4fForCloudsOnly = matrixStack.peek().getPositionMatrix();
+	}
+
+	public Matrix4f getLongerBasicProjectionMatrix(double fov) {
+		MatrixStack matrixStack = new MatrixStack();
+		matrixStack.peek().getPositionMatrix().loadIdentity();
+		if (this.zoom != 1.0F) {
+			matrixStack.translate((double)this.zoomX, (double)(-this.zoomY), 0.0D);
+			matrixStack.scale(this.zoom, this.zoom, 1.0F);
+		}
+		matrixStack.peek().getPositionMatrix().multiply(Matrix4f.viewboxMatrix(fov, (float)this.client.getWindow().getFramebufferWidth() / (float)this.client.getWindow().getFramebufferHeight(), 0.05F, (float) (this.method_32796()*cloudConfigData.getTestedModifier())));
+		return matrixStack.peek().getPositionMatrix();
+	}
+}

--- a/src/main/java/net/oskarstrom/extendedclouds/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/oskarstrom/extendedclouds/mixin/WorldRendererMixin.java
@@ -1,25 +1,33 @@
 package net.oskarstrom.extendedclouds.mixin;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.option.CloudRenderMode;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Matrix4f;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+import static net.oskarstrom.extendedclouds.ClientEntrypoint.cloudConfigData;
+import static net.oskarstrom.extendedclouds.ClientEntrypoint.matrix4fForCloudsOnly;
 
 @Mixin(WorldRenderer.class)
 public class WorldRendererMixin {
 	@Shadow
 	private int viewDistance;
 
-	@Shadow
-	private @Nullable CloudRenderMode lastCloudsRenderMode;
-
 	private float oldFogEnd = 0;
+
+	@ModifyArgs(
+			method = "renderClouds(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/math/Matrix4f;FDDD)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/VertexBuffer;draw(Lnet/minecraft/util/math/Matrix4f;Lnet/minecraft/util/math/Matrix4f;Lnet/minecraft/client/render/Shader;)V")
+	)
+	private void injected(Args args) {
+		//replace the vanilla projection matrix with our extended one to allow further away clouds than the vanilla rendering does
+		if (matrix4fForCloudsOnly != null) args.set(1, matrix4fForCloudsOnly);
+	}
 
 	@Inject(
 			method = "renderClouds(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/math/Matrix4f;FDDD)V",
@@ -27,7 +35,7 @@ public class WorldRendererMixin {
 	)
 	private void fixFoxStart(MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta, double d, double e, double f, CallbackInfo ci) {
 		oldFogEnd = RenderSystem.getShaderFogEnd();
-		RenderSystem.setShaderFogEnd((viewDistance * 8) * 10);
+		RenderSystem.setShaderFogEnd((viewDistanceModified() * 8) * 10);
 	}
 
 	@Inject(
@@ -39,35 +47,42 @@ public class WorldRendererMixin {
 	}
 
 	@ModifyConstant(
-			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)V",
+			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)Lnet/minecraft/client/render/BufferBuilder$BuiltBuffer;",
 			constant = @Constant(intValue = -3)
 	)
 	private int fancyForStart(int constant) {
-		return -(viewDistance - 1);
+		return -(viewDistanceModified() - 1);
 	}
 
 	@ModifyConstant(
-			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)V",
+			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)Lnet/minecraft/client/render/BufferBuilder$BuiltBuffer;",
 			constant = @Constant(intValue = 4)
 	)
 	private int fancyForEnd(int constant) {
-		return viewDistance;
+		return viewDistanceModified();
 	}
 
 	@ModifyConstant(
-			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)V",
+			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)Lnet/minecraft/client/render/BufferBuilder$BuiltBuffer;",
 			constant = @Constant(intValue = -32)
 	)
 	private int fastForStart(int constant) {
-		return -(viewDistance * 4);
+		return -(viewDistanceModified() * 4);
 	}
 
 	@ModifyConstant(
-			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)V",
+			method = "renderClouds(Lnet/minecraft/client/render/BufferBuilder;DDDLnet/minecraft/util/math/Vec3d;)Lnet/minecraft/client/render/BufferBuilder$BuiltBuffer;",
 			constant = @Constant(intValue = 32)
 	)
 	private int fastForEnd(int constant) {
-		return (viewDistance * 4);
+		return (viewDistanceModified() * 4);
 	}
+
+	//config support for distance scaling
+	private int viewDistanceModified(){
+		return  (int) (viewDistance * cloudConfigData.getTestedModifier());
+	}
+
+
 
 }

--- a/src/main/resources/extendedclouds.mixins.json
+++ b/src/main/resources/extendedclouds.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [],
   "client": [
+    "GameRendererMixin",
     "WorldRendererMixin"
   ],
   "injectors": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,17 +4,25 @@
   "version": "${version}",
   "name": "Extended Clouds",
   "icon": "assets/extendedclouds/icon.png",
-  "description": "Makes clouds render further out.",
+  "description": "Makes clouds render further out.\nDistance can be set via config file.",
   "authors": [
     "notequalalpha"
   ],
+  "contributors": [
+    "Traben"
+  ],
   "environment": "client",
+  "entrypoints": {
+    "client": [
+      "net.oskarstrom.extendedclouds.ClientEntrypoint"
+    ]
+  },
   "mixins": [
     "extendedclouds.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.13.3",
-    "minecraft": "~1.18.2",
+    "fabricloader": ">=0.14",
+    "minecraft": ">=1.19",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
updated to 1.19

Added config file support to allow user customizing cloud render distance.
This required extending the projection map used to render clouds, so they can be seen further than vanilla allows, this has been done in a way to only affect clouds.

